### PR TITLE
added admin user in env instead of hard coded

### DIFF
--- a/app/Command/Twitch/DefaultController.php
+++ b/app/Command/Twitch/DefaultController.php
@@ -155,7 +155,7 @@ class DefaultController extends CommandController
         }
 
         if (preg_match('/!canal \w+/', $msg)) {
-            if ($user == 'felipez3r0') {
+            if ($user == ADMIN_USER) {
                 $canal = explode(' ', $msg)[1];
                 $this->sendMessage('!sh-so ' . $canal);
             }

--- a/env-example.php
+++ b/env-example.php
@@ -3,3 +3,4 @@
 define('TWITCH_USER','USER');
 define('TWITCH_AUTH','OAUTH');
 define('TWITCH_CHANNEL','CANAL');
+define('ADMIN_USER','felipez3r0');


### PR DESCRIPTION
The admin user who can select the channel of the bot should not be hardcoded and should be part of the env